### PR TITLE
remove TSLint extension from recomended

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,6 +6,5 @@
     "editorconfig.editorconfig",
     "davidanson.vscode-markdownlint",
     "spmeesseman.vscode-taskexplorer",
-    "ms-vscode.vscode-typescript-tslint-plugin"
   ]
 }


### PR DESCRIPTION
Because now it uses the generic ESLint extension.